### PR TITLE
Fix nginx config

### DIFF
--- a/docker-conf/nginx/segment-admin-panel.conf.template
+++ b/docker-conf/nginx/segment-admin-panel.conf.template
@@ -8,7 +8,7 @@ server {
     index  index.html;
 
     location / {
-        try_files $uri $uri/ $uri.html /index.html;
+        try_files ${DOLLAR}uri ${DOLLAR}uri/ ${DOLLAR}uri.html /index.html;
     }
 
     location ~ /api/ {


### PR DESCRIPTION
Забыл экранировать `$` переменной `${DOLLAR}` и поэтому при выполнении `envsubst` получался некорректный файл конфигурации.