### PR TITLE
Исправить сборку docker образа на windows и настройки nginx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN yarn install
 
 COPY . .
 
-RUN yarn build
+RUN yarn lint && yarn build
 
 
 FROM nginx:alpine
@@ -17,9 +17,11 @@ ENV API_HOST="http://host.docker.internal"
 
 ENV API_PORT=8080
 
+ENV DOLLAR="$"
+
 COPY ./docker-conf/nginx/segment-admin-panel.conf.template /etc/nginx/conf.d/
 
-COPY ./docker-conf/start.sh .
+RUN envsubst < /etc/nginx/conf.d/segment-admin-panel.conf.template > /etc/nginx/conf.d/default.conf
 
 WORKDIR /var/www/html
 
@@ -27,4 +29,4 @@ COPY --from=builder /app/build .
 
 EXPOSE 80
 
-ENTRYPOINT ["/start.sh"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
   docker run -d --rm --name segment-front -e API_PORT=3000 -p 80:80 segment-front
 ```
 
+API будет доступен по адресу [http://localhost/api](http://localhost/api).
+
 ### Остановка контейнера
 
 Для остановки контейнера выполните команду:

--- a/docker-conf/nginx/segment-admin-panel.conf.template
+++ b/docker-conf/nginx/segment-admin-panel.conf.template
@@ -11,8 +11,8 @@ server {
         try_files ${DOLLAR}uri ${DOLLAR}uri/ ${DOLLAR}uri.html /index.html;
     }
 
-    location ~ /api/ {
-        proxy_pass        ${API_HOST}:${API_PORT};
+    location /api/ {
+        proxy_pass        ${API_HOST}:${API_PORT}/;
         proxy_set_header  Host ${DOLLAR}http_host;
         proxy_set_header  X-Real-IP ${DOLLAR}remote_addr;
         proxy_set_header  X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;

--- a/docker-conf/start.sh
+++ b/docker-conf/start.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-export DOLLAR="$"
-envsubst < /etc/nginx/conf.d/segment-admin-panel.conf.template > /etc/nginx/conf.d/default.conf
-nginx -g "daemon off;"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --fix"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
Добавил в скрипт lint флаг --fix.
Вынес команды из start.sh в Dockerfile.
Перед yarn build добавил команду yarn lint для замены CRLF на LF.
Исправил настройки nginx, чтобы при проксировании запросов удалялась лишняя чать URI (`/api/`).