### PR TITLE
Добавить страницу "Основная информация"

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,7 +16,7 @@ const apiErrorHandler = (error: unknown): ApiError => {
     if (isAxiosError(error)) {
         if (error.response) {
             console.error(`${error.name}: ${error.message}`, error.response);
-            return { message: 'Произошла ошибка. Попробуйте перезагрузить страницу' };
+            return { message: 'Произошла ошибка. Попробуйте перезагрузить страницу', code: error.response.status };
         }
 
         if (error.request) {

--- a/src/components/LayerStatusChip.tsx
+++ b/src/components/LayerStatusChip.tsx
@@ -1,23 +1,23 @@
 import ArchivedIcon from '@mui/icons-material/ArchiveOutlined';
 import StableIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import ExperimentalIcon from '@mui/icons-material/ScienceOutlined';
-import Chip from '@mui/material/Chip';
+import Chip, { ChipProps } from '@mui/material/Chip';
 
 import exhaustiveCheck from 'helpers/exhaustiveCheck';
 import { LayerStatus } from 'models/layersList';
 
-interface LayerStatusChipProps {
+interface LayerStatusChipProps extends Pick<ChipProps, 'variant'> {
     status: LayerStatus;
 }
 
-const LayerStatusChip: React.FC<LayerStatusChipProps> = ({ status }) => {
+const LayerStatusChip: React.FC<LayerStatusChipProps> = ({ status, variant }) => {
     switch (status) {
         case 'ARCHIVED':
-            return <Chip icon={<ArchivedIcon />} label="Архивный" variant="outlined" />;
+            return <Chip icon={<ArchivedIcon />} label="Архивный" variant={variant} />;
         case 'EXPERIMENTAL':
-            return <Chip icon={<ExperimentalIcon />} label="Пробный" variant="outlined" color="warning" />;
+            return <Chip icon={<ExperimentalIcon />} label="Пробный" variant={variant} color="warning" />;
         case 'STABLE':
-            return <Chip icon={<StableIcon />} label="Базовый" variant="outlined" color="success" />;
+            return <Chip icon={<StableIcon />} label="Базовый" variant={variant} color="success" />;
     }
     return exhaustiveCheck(status);
 };

--- a/src/components/LayersTable.tsx
+++ b/src/components/LayersTable.tsx
@@ -54,7 +54,7 @@ const convertData: DataConverter<LayersListItem, 'actions'> = (key, data): React
                 timeStyle: 'medium',
             });
         case 'layerStatus':
-            return <LayerStatusChip status={data[key]} />;
+            return <LayerStatusChip status={data[key]} variant="outlined" />;
         case 'actions':
             return (
                 <Button href={`/layers/${data.id}/info`} size="small">

--- a/src/components/ParentsLayersTable.tsx
+++ b/src/components/ParentsLayersTable.tsx
@@ -1,0 +1,78 @@
+import { shallowEqual } from 'react-redux';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableContainer from '@mui/material/TableContainer';
+
+import exhaustiveCheck from 'helpers/exhaustiveCheck';
+import { useAppSelector } from 'hooks/redux-hooks';
+import { selectCurrentLayerParentLayers } from 'models/currentLayer';
+import { LayersListItem, LayersList } from 'models/layersList';
+
+import LayerStatusChip from 'components/LayerStatusChip';
+import TableDataRow, { DataConverter, DEFAULT_ROW_HEIGHT } from 'components/Table/TableDataRow';
+import TableEmptyRow from 'components/Table/TableEmptyRow';
+import TableHead, { Column } from 'components/Table/TableHead';
+
+const columns: Column<LayersListItem>[] = [
+    {
+        key: 'createTime',
+        headerName: 'Создан',
+        align: 'center',
+        width: '180px',
+    },
+    {
+        key: 'title',
+        headerName: 'Наименование',
+        align: 'center',
+    },
+    {
+        key: 'layerStatus',
+        headerName: 'Статус',
+        align: 'center',
+        width: '160px',
+    },
+    {
+        key: 'id',
+        headerName: 'ID',
+        align: 'center',
+    },
+];
+
+const convertData: DataConverter<LayersListItem> = (key, data): React.ReactNode => {
+    switch (key) {
+        case 'id':
+        case 'title':
+            return data[key];
+        case 'createTime':
+            return new Date(data[key]).toLocaleString('ru', {
+                dateStyle: 'short',
+                timeStyle: 'medium',
+            });
+        case 'layerStatus':
+            return <LayerStatusChip status={data[key]} variant="outlined" />;
+    }
+    return exhaustiveCheck(key);
+};
+
+const renderBody = (columns: Column<LayersListItem>[], rows: LayersList | null): React.ReactNode => {
+    if (rows == null || rows.length === 0) {
+        return <TableEmptyRow columnsCount={columns.length} text="Родительского слоя нет." />;
+    }
+
+    return rows.map((row) => <TableDataRow key={row.id} columns={columns} row={row} dataConverter={convertData} />);
+};
+
+const LayersTable: React.FC = () => {
+    const items = useAppSelector(selectCurrentLayerParentLayers, shallowEqual);
+
+    return (
+        <TableContainer sx={{ maxHeight: DEFAULT_ROW_HEIGHT * 4 }}>
+            <Table stickyHeader>
+                <TableHead columns={columns} />
+                <TableBody>{renderBody(columns, items)}</TableBody>
+            </Table>
+        </TableContainer>
+    );
+};
+
+export default LayersTable;

--- a/src/components/ParentsLayersTable.tsx
+++ b/src/components/ParentsLayersTable.tsx
@@ -55,7 +55,7 @@ const convertData: DataConverter<LayersListItem> = (key, data): React.ReactNode 
 };
 
 const renderBody = (columns: Column<LayersListItem>[], rows: LayersList | null): React.ReactNode => {
-    if (rows == null || rows.length === 0) {
+    if (rows === null || rows.length === 0) {
         return <TableEmptyRow columnsCount={columns.length} text="Родительского слоя нет." />;
     }
 

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -4,6 +4,7 @@ import { styled } from '@mui/material/styles';
 const Wrapper = styled('div')({
     display: 'flex',
     minHeight: '100vh',
+    overflow: 'auto',
     backgroundColor: grey[50],
 });
 

--- a/src/layouts/LayerLayout.tsx
+++ b/src/layouts/LayerLayout.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
+import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
+import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
@@ -19,11 +21,12 @@ interface LayerLayoutProps {
     drawerOptions: Omit<DrawerOptionProps, 'onClick'>[];
     children?: React.ReactNode;
     title?: React.ReactNode;
+    loading?: boolean;
 }
 
 const drawerWidth = 290;
 
-const LayerLayout: React.FC<LayerLayoutProps> = ({ children, title, drawerOptions }) => {
+const LayerLayout: React.FC<LayerLayoutProps> = ({ children, title, drawerOptions, loading }) => {
     const [open, setOpen] = useState(false);
     const theme = useTheme();
     const isSmallWindow = useMediaQuery(theme.breakpoints.down('md'));
@@ -46,9 +49,11 @@ const LayerLayout: React.FC<LayerLayoutProps> = ({ children, title, drawerOption
                     <BackButton href="/" tooltipTitle="На главную" />
                     {isSmallWindow && <DrawerButton onClick={handleDrawerToggle} />}
                 </Stack>
-                <Typography variant="h6" noWrap component="h1" sx={{ ml: 3 }}>
-                    {title}
-                </Typography>
+                <Box sx={{ ml: 3 }}>
+                    <Typography variant="h6" noWrap component="h1">
+                        {loading ? <Skeleton width={250} /> : title}
+                    </Typography>
+                </Box>
             </AppBar>
             <Drawer
                 open={open}

--- a/src/models/currentLayer.ts
+++ b/src/models/currentLayer.ts
@@ -79,14 +79,14 @@ const selectCurrentLayerError = (state: RootState): ApiError | null => state.cur
 const selectCurrentLayerLoadingStatus = (state: RootState): boolean => state.currentLayer.isLoading;
 const selectCurrentLayerTitle = (state: RootState): string => {
     const item = state.currentLayer.item;
-    if (item == null) {
+    if (item === null) {
         return '';
     }
     return item.title;
 };
 const selectCurrentLayerParentLayers = (state: RootState): LayersList | null => {
     const item = state.currentLayer.item;
-    if (item == null) {
+    if (item === null) {
         return item;
     }
     return item.parentLayersList;

--- a/src/models/currentLayer.ts
+++ b/src/models/currentLayer.ts
@@ -1,0 +1,104 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { AxiosResponse } from 'axios';
+
+import api, { GET_LAYERS_URL, ApiError, apiErrorHandler } from 'api';
+import { RootState } from 'store';
+
+import { LayersList, LayerStatus } from 'models/layersList';
+
+export interface Layer {
+    id: number;
+    title: string;
+    description: string;
+    createTime: string;
+    layerStatus: LayerStatus;
+    parentLayersList: LayersList;
+}
+
+interface CurrentLayerState {
+    item: Layer | null;
+    isLoading: boolean;
+    error: ApiError | null;
+}
+
+const fetchLayer = createAsyncThunk<Layer, number, { rejectValue: ApiError }>(
+    'currentLayer/fetchLayer',
+    async (id, thunkApi) => {
+        let response: AxiosResponse<Layer>;
+
+        try {
+            response = await api.get<Layer>(`${GET_LAYERS_URL}/${id}`);
+        } catch (error) {
+            return thunkApi.rejectWithValue(apiErrorHandler(error));
+        }
+
+        return response.data;
+    }
+);
+
+const initialState: CurrentLayerState = {
+    item: null,
+    isLoading: false,
+    error: null,
+};
+
+const currentLayerSlice = createSlice({
+    name: 'currentLayer',
+    initialState,
+    reducers: {
+        remove: (state) => {
+            state.item = null;
+            state.error = null;
+            return state;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchLayer.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchLayer.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.item = action.payload;
+            })
+            .addCase(fetchLayer.rejected, (state, action) => {
+                state.isLoading = false;
+
+                if (action.payload != null) {
+                    state.error = action.payload;
+                } else {
+                    state.error = { message: 'Произошла непредвиденная ошибка' };
+                }
+            });
+    },
+});
+
+const selectCurrentLayer = (state: RootState): Layer | null => state.currentLayer.item;
+const selectCurrentLayerError = (state: RootState): ApiError | null => state.currentLayer.error;
+const selectCurrentLayerLoadingStatus = (state: RootState): boolean => state.currentLayer.isLoading;
+const selectCurrentLayerTitle = (state: RootState): string => {
+    const item = state.currentLayer.item;
+    if (item == null) {
+        return '';
+    }
+    return item.title;
+};
+const selectCurrentLayerParentLayers = (state: RootState): LayersList | null => {
+    const item = state.currentLayer.item;
+    if (item == null) {
+        return item;
+    }
+    return item.parentLayersList;
+};
+
+export default currentLayerSlice.reducer;
+export const { remove } = currentLayerSlice.actions;
+export {
+    fetchLayer,
+    selectCurrentLayer,
+    selectCurrentLayerTitle,
+    selectCurrentLayerError,
+    selectCurrentLayerLoadingStatus,
+    selectCurrentLayerParentLayers,
+};

--- a/src/pages/InfoPage.tsx
+++ b/src/pages/InfoPage.tsx
@@ -1,7 +1,80 @@
-import UnderConstructionPage from 'pages/UnderConstructionPage';
+import { shallowEqual } from 'react-redux';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+
+import DataCard from 'components/DataCard';
+import DataCardContent from 'components/DataCard/DataCardContent';
+import DataCardSubtitle from 'components/DataCard/DataCardSubtitle';
+import LayerStatusChip from 'components/LayerStatusChip';
+import ParentsLayersTable from 'components/ParentsLayersTable';
+import { useAppSelector } from 'hooks/redux-hooks';
+import { selectCurrentLayer, selectCurrentLayerLoadingStatus } from 'models/currentLayer';
 
 const InfoPage: React.FC = () => {
-    return <UnderConstructionPage pageName="Основная информация" />;
+    const layer = useAppSelector(selectCurrentLayer, shallowEqual);
+    const isLoading = useAppSelector(selectCurrentLayerLoadingStatus);
+
+    if (isLoading) {
+        return (
+            <>
+                <DataCard title="Общая информация" margin>
+                    <DataCardContent>
+                        <Skeleton variant="rounded" height={80} />
+                    </DataCardContent>
+                </DataCard>
+                <DataCard title="Родительский слой">
+                    <DataCardContent>
+                        <Skeleton variant="rounded" height={80} />
+                    </DataCardContent>
+                </DataCard>
+            </>
+        );
+    }
+
+    if (layer == null) {
+        return (
+            <>
+                <DataCard title="Общая информация" margin>
+                    <DataCardContent>
+                        <Typography>Нет данных.</Typography>
+                    </DataCardContent>
+                </DataCard>
+                <DataCard title="Родительский слой">
+                    <DataCardContent>
+                        <Typography>Нет данных.</Typography>
+                    </DataCardContent>
+                </DataCard>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <DataCard title="Общая информация" margin>
+                <DataCardContent>
+                    <LayerStatusChip status={layer.layerStatus} />
+                </DataCardContent>
+                <DataCardSubtitle>Описание</DataCardSubtitle>
+                <DataCardContent>
+                    <Typography>{layer.description}</Typography>
+                </DataCardContent>
+                <DataCardSubtitle>Дата создания</DataCardSubtitle>
+                <DataCardContent>
+                    <Typography>
+                        {new Date(layer.createTime).toLocaleString('ru', {
+                            dateStyle: 'long',
+                            timeStyle: 'medium',
+                        })}
+                    </Typography>
+                </DataCardContent>
+            </DataCard>
+            <DataCard title="Родительский слой">
+                <DataCardContent>
+                    <ParentsLayersTable />
+                </DataCardContent>
+            </DataCard>
+        </>
+    );
 };
 
 export default InfoPage;

--- a/src/pages/InfoPage.tsx
+++ b/src/pages/InfoPage.tsx
@@ -31,7 +31,7 @@ const InfoPage: React.FC = () => {
         );
     }
 
-    if (layer == null) {
+    if (layer === null) {
         return (
             <>
                 <DataCard title="Общая информация" margin>

--- a/src/pages/LayerPage.tsx
+++ b/src/pages/LayerPage.tsx
@@ -1,4 +1,6 @@
-import { Outlet, useParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { shallowEqual } from 'react-redux';
+import { Outlet, redirect, useParams } from 'react-router-dom';
 import SegmentsIcon from '@mui/icons-material/DonutSmallOutlined';
 import InfoIcon from '@mui/icons-material/InfoOutlined';
 import LayerIcon from '@mui/icons-material/LibraryAddOutlined';
@@ -6,10 +8,41 @@ import EntryPointIcon from '@mui/icons-material/OpenInNewOutlined';
 import FieldsIcon from '@mui/icons-material/QuestionAnswerOutlined';
 import GroupFieldsIcon from '@mui/icons-material/QuizOutlined';
 
+import { useAppDispatch, useAppSelector } from 'hooks/redux-hooks';
+import useErrorAlert from 'hooks/useErrorAlert';
 import LayerLayout from 'layouts/LayerLayout';
+import {
+    remove,
+    fetchLayer,
+    selectCurrentLayerTitle,
+    selectCurrentLayerError,
+    selectCurrentLayerLoadingStatus,
+} from 'models/currentLayer';
 
 const LayerPage: React.FC = () => {
-    const { entryPointId, fieldId } = useParams();
+    const { layerId, entryPointId, fieldId } = useParams();
+    const dispatch = useAppDispatch();
+    const title = useAppSelector(selectCurrentLayerTitle);
+    const error = useAppSelector(selectCurrentLayerError, shallowEqual);
+    const isLoading = useAppSelector(selectCurrentLayerLoadingStatus);
+    const { setAlert } = useErrorAlert();
+
+    useEffect(() => {
+        if (layerId != null) {
+            void dispatch(fetchLayer(Number(layerId)));
+        }
+        return () => void dispatch(remove());
+    }, [layerId, dispatch]);
+
+    useEffect(() => {
+        if (error != null) {
+            if (error.code === 404) {
+                redirect('/not-found');
+            } else {
+                setAlert(error.message);
+            }
+        }
+    }, [error, setAlert]);
 
     if (entryPointId != null || fieldId != null) {
         return <Outlet />;
@@ -25,7 +58,8 @@ const LayerPage: React.FC = () => {
                 { href: 'fields', primaryText: 'Поля', icon: <FieldsIcon /> },
                 { href: 'field-groups', primaryText: 'Группы полей', icon: <GroupFieldsIcon /> },
             ]}
-            title="Водитель за 50"
+            title={title}
+            loading={isLoading}
         >
             <Outlet />
         </LayerLayout>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,12 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 
+import currentLayerReducer from 'models/currentLayer';
 import layersListReducer from 'models/layersList';
 
 export const store = configureStore({
     reducer: {
         layersList: layersListReducer,
+        currentLayer: currentLayerReducer,
     },
 });
 


### PR DESCRIPTION
- добавил prop variant в LayerStatusChip;
- добавил компонент ParentsLayersTable (для отображения родительского слоя);
- добавил скелетон для загаловка (название слоя) в LayerLayout;
- добавил модель currentLayer;
- добавил логику по загузке данных о слое в LayerPage;
- сверстал страницу InfoPage;
- добавил свойство overflow у Wrapper для исправления отображения на мобильных устройствах;
- добавил запись значения кода в apiErrorHandler для перенаправления на страницу 404 при соответствующей ошибке.

**Загрузка:**
![Снимок экрана от 2023-04-21 19-23-07](https://user-images.githubusercontent.com/84242545/233689971-c7380929-a380-419f-aa65-69181c9de04c.png)

**Если есть родительский слой**
![Снимок экрана от 2023-04-21 19-22-45](https://user-images.githubusercontent.com/84242545/233690106-b9a66e3d-035d-4e2d-b4b7-ffd165da2b7d.png)

**Если нет родительского слоя**
![Снимок экрана от 2023-04-21 19-23-19](https://user-images.githubusercontent.com/84242545/233690188-16be1336-c55e-498a-939d-6e1092de1c9a.png)

**Если произошла ошибка и нет данных**
![Снимок экрана от 2023-04-21 19-23-48](https://user-images.githubusercontent.com/84242545/233690383-63aedd7e-e8da-455a-a1df-b21b0f2d0703.png)

