### PR TITLE
Сверстать страницу "Экраны"

### DIFF
--- a/src/components/Drawer/DrawerWrapper.tsx
+++ b/src/components/Drawer/DrawerWrapper.tsx
@@ -5,7 +5,7 @@ interface DrawerWrapperProps {
 }
 
 const DrawerWrapper = styled('nav', { shouldForwardProp: (prop) => prop !== 'drawerWidth' })<DrawerWrapperProps>(
-    ({ theme, drawerWidth }) => ({ [theme.breakpoints.up('md')]: { width: drawerWidth, flexShrink: 0 } })
+    ({ theme, drawerWidth }) => ({ [theme.breakpoints.up('lg')]: { width: drawerWidth, flexShrink: 0 } })
 );
 
 export default DrawerWrapper;

--- a/src/components/Screen/ScreenAppVersions.tsx
+++ b/src/components/Screen/ScreenAppVersions.tsx
@@ -11,18 +11,15 @@ interface ScreenAppVersionsProps {
     filtered?: boolean;
 }
 
-const StyledList = styled(List, { shouldForwardProp: (prop) => prop !== 'filtered' })<
-    Pick<ScreenAppVersionsProps, 'filtered'>
->(({ filtered }) => ({
+const StyledList = styled(List)({
     padding: '4px 0',
     borderRadius: '4px',
     backgroundColor: '#dee3e9',
-    ...(filtered && { backgroundColor: '#e5e5e5' }),
-}));
+});
 
-const ScreenAppVersions: React.FC<ScreenAppVersionsProps> = ({ versions, filtered }) => {
+const ScreenAppVersions: React.FC<ScreenAppVersionsProps> = ({ versions }) => {
     return (
-        <StyledList filtered={filtered}>
+        <StyledList>
             {versions.map(({ id, platform, version }) => (
                 <ListItem key={id} sx={{ py: 0 }}>
                     <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>

--- a/src/components/Screen/ScreenAppVersions.tsx
+++ b/src/components/Screen/ScreenAppVersions.tsx
@@ -1,0 +1,38 @@
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+
+import { VersionsList } from 'models/screens';
+
+interface ScreenAppVersionsProps {
+    versions: VersionsList;
+    filtered?: boolean;
+}
+
+const StyledList = styled(List, { shouldForwardProp: (prop) => prop !== 'filtered' })<
+    Pick<ScreenAppVersionsProps, 'filtered'>
+>(({ filtered }) => ({
+    padding: '4px 0',
+    borderRadius: '4px',
+    backgroundColor: '#dee3e9',
+    ...(filtered && { backgroundColor: '#e5e5e5' }),
+}));
+
+const ScreenAppVersions: React.FC<ScreenAppVersionsProps> = ({ versions, filtered }) => {
+    return (
+        <StyledList filtered={filtered}>
+            {versions.map(({ id, platform, version }) => (
+                <ListItem key={id} sx={{ py: 0 }}>
+                    <Stack direction="row" justifyContent="space-between" sx={{ width: '100%' }}>
+                        <Typography variant="body2">{platform}</Typography>
+                        <Typography variant="body2">{version}</Typography>
+                    </Stack>
+                </ListItem>
+            ))}
+        </StyledList>
+    );
+};
+
+export default ScreenAppVersions;

--- a/src/components/Screen/ScreenFieldsList.tsx
+++ b/src/components/Screen/ScreenFieldsList.tsx
@@ -1,0 +1,48 @@
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import { styled } from '@mui/material/styles';
+
+import { FieldsList } from 'models/screens';
+
+import { Variant } from 'components/Screen';
+
+interface ScreenFieldsListProps {
+    fields: FieldsList;
+    variant?: `${Variant}`;
+    filtered?: boolean;
+}
+
+const StyledList = styled(List, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
+    Pick<ScreenFieldsListProps, 'variant' | 'filtered'>
+>(({ variant = Variant.STATIC, filtered }) => ({
+    backgroundClip: 'content-box',
+    ...(variant === Variant.STATIC && { backgroundColor: '#fff2f2' }),
+    ...(variant === Variant.DYNAMIC && { backgroundColor: '#e8f1fb' }),
+    ...(filtered && { backgroundColor: '#f2f2f2' }),
+}));
+
+const StyledListItem = styled(ListItem, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
+    Pick<ScreenFieldsListProps, 'variant' | 'filtered'>
+>(({ variant = Variant.STATIC, filtered }) => ({
+    ...(variant === Variant.STATIC && { '&:nth-of-type(even)': { backgroundColor: '#ffe6e6' } }),
+    ...(variant === Variant.DYNAMIC && { '&:nth-of-type(odd)': { backgroundColor: '#d1e4f6' } }),
+    ...(filtered && {
+        '&:nth-of-type(even)': { backgroundColor: '#e5e5e5' },
+        '&:nth-of-type(odd)': { backgroundColor: 'unset' },
+    }),
+}));
+
+const ScreenFieldsList: React.FC<ScreenFieldsListProps> = ({ fields, variant, filtered }) => {
+    return (
+        <StyledList variant={variant} filtered={filtered}>
+            {fields.map(({ id, title }) => (
+                <StyledListItem key={id} variant={variant} filtered={filtered} dense>
+                    <ListItemText primary={title} />
+                </StyledListItem>
+            ))}
+        </StyledList>
+    );
+};
+
+export default ScreenFieldsList;

--- a/src/components/Screen/ScreenFieldsList.tsx
+++ b/src/components/Screen/ScreenFieldsList.tsx
@@ -10,34 +10,28 @@ import { Variant } from 'components/Screen';
 interface ScreenFieldsListProps {
     fields: FieldsList;
     variant?: `${Variant}`;
-    filtered?: boolean;
 }
 
-const StyledList = styled(List, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
-    Pick<ScreenFieldsListProps, 'variant' | 'filtered'>
->(({ variant = Variant.STATIC, filtered }) => ({
+const StyledList = styled(List, { shouldForwardProp: (prop) => prop !== 'variant' })<
+    Pick<ScreenFieldsListProps, 'variant'>
+>(({ variant = Variant.STATIC }) => ({
     backgroundClip: 'content-box',
     ...(variant === Variant.STATIC && { backgroundColor: '#fff2f2' }),
     ...(variant === Variant.DYNAMIC && { backgroundColor: '#e8f1fb' }),
-    ...(filtered && { backgroundColor: '#f2f2f2' }),
 }));
 
-const StyledListItem = styled(ListItem, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
-    Pick<ScreenFieldsListProps, 'variant' | 'filtered'>
->(({ variant = Variant.STATIC, filtered }) => ({
+const StyledListItem = styled(ListItem, { shouldForwardProp: (prop) => prop !== 'variant' })<
+    Pick<ScreenFieldsListProps, 'variant'>
+>(({ variant = Variant.STATIC }) => ({
     ...(variant === Variant.STATIC && { '&:nth-of-type(even)': { backgroundColor: '#ffe6e6' } }),
     ...(variant === Variant.DYNAMIC && { '&:nth-of-type(odd)': { backgroundColor: '#d1e4f6' } }),
-    ...(filtered && {
-        '&:nth-of-type(even)': { backgroundColor: '#e5e5e5' },
-        '&:nth-of-type(odd)': { backgroundColor: 'unset' },
-    }),
 }));
 
-const ScreenFieldsList: React.FC<ScreenFieldsListProps> = ({ fields, variant, filtered }) => {
+const ScreenFieldsList: React.FC<ScreenFieldsListProps> = ({ fields, variant }) => {
     return (
-        <StyledList variant={variant} filtered={filtered}>
+        <StyledList variant={variant}>
             {fields.map(({ id, title }) => (
-                <StyledListItem key={id} variant={variant} filtered={filtered} dense>
+                <StyledListItem key={id} variant={variant} dense>
                     <ListItemText primary={title} />
                 </StyledListItem>
             ))}

--- a/src/components/Screen/index.tsx
+++ b/src/components/Screen/index.tsx
@@ -1,5 +1,6 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { grey } from '@mui/material/colors';
 import { styled } from '@mui/material/styles';
 
 import { FieldsList, VersionsList } from 'models/screens';
@@ -30,7 +31,7 @@ const ScreenCard = styled(Stack, { shouldForwardProp: (prop) => prop !== 'varian
     borderRadius: '4px',
     ...(variant === Variant.STATIC && { backgroundColor: '#ffd1d1' }),
     ...(variant === Variant.DYNAMIC && { backgroundColor: '#75ade4' }),
-    ...(filtered && { color: '#999999', backgroundColor: '#cccccc' }),
+    ...(filtered && { color: grey[600], filter: 'grayscale(1)' }),
 }));
 
 const Screen: React.FC<ScreenProps> = ({ title, fields, appVersions, variant, filtered }) => {
@@ -38,8 +39,8 @@ const Screen: React.FC<ScreenProps> = ({ title, fields, appVersions, variant, fi
         <ScreenCard variant={variant} filtered={filtered}>
             <Typography sx={{ fontWeight: '700', textAlign: 'center' }}>{title}</Typography>
             <Stack justifyContent="space-between" flexGrow={1}>
-                <ScreenFieldsList variant={variant} fields={fields} filtered={filtered} />
-                <ScreenAppVersions versions={appVersions} filtered={filtered} />
+                <ScreenFieldsList variant={variant} fields={fields} />
+                <ScreenAppVersions versions={appVersions} />
             </Stack>
         </ScreenCard>
     );

--- a/src/components/Screen/index.tsx
+++ b/src/components/Screen/index.tsx
@@ -1,0 +1,48 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+
+import { FieldsList, VersionsList } from 'models/screens';
+
+import ScreenAppVersions from 'components/Screen/ScreenAppVersions';
+import ScreenFieldsList from 'components/Screen/ScreenFieldsList';
+
+export const enum Variant {
+    STATIC = 'static',
+    DYNAMIC = 'dynamic',
+}
+
+export interface ScreenProps {
+    title: string;
+    fields: FieldsList;
+    appVersions: VersionsList;
+    variant?: `${Variant}`;
+    filtered?: boolean;
+}
+
+const ScreenCard = styled(Stack, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
+    Pick<ScreenProps, 'variant' | 'filtered'>
+>(({ variant = Variant.STATIC, filtered }) => ({
+    height: '100%',
+    minHeight: '280px',
+    width: '200px',
+    padding: '16px 8px 8px',
+    borderRadius: '4px',
+    ...(variant === Variant.STATIC && { backgroundColor: '#ffd1d1' }),
+    ...(variant === Variant.DYNAMIC && { backgroundColor: '#75ade4' }),
+    ...(filtered && { color: '#999999', backgroundColor: '#cccccc' }),
+}));
+
+const Screen: React.FC<ScreenProps> = ({ title, fields, appVersions, variant, filtered }) => {
+    return (
+        <ScreenCard variant={variant} filtered={filtered}>
+            <Typography sx={{ fontWeight: '700', textAlign: 'center' }}>{title}</Typography>
+            <Stack justifyContent="space-between" flexGrow={1}>
+                <ScreenFieldsList variant={variant} fields={fields} filtered={filtered} />
+                <ScreenAppVersions versions={appVersions} filtered={filtered} />
+            </Stack>
+        </ScreenCard>
+    );
+};
+
+export default Screen;

--- a/src/components/Screen/index.tsx
+++ b/src/components/Screen/index.tsx
@@ -1,6 +1,5 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { grey } from '@mui/material/colors';
 import { styled } from '@mui/material/styles';
 
 import { FieldsList, VersionsList } from 'models/screens';
@@ -23,7 +22,7 @@ export interface ScreenProps {
 
 const ScreenCard = styled(Stack, { shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'filtered' })<
     Pick<ScreenProps, 'variant' | 'filtered'>
->(({ variant = Variant.STATIC, filtered }) => ({
+>(({ theme, variant = Variant.STATIC, filtered }) => ({
     height: '100%',
     minHeight: '280px',
     width: '200px',
@@ -31,7 +30,7 @@ const ScreenCard = styled(Stack, { shouldForwardProp: (prop) => prop !== 'varian
     borderRadius: '4px',
     ...(variant === Variant.STATIC && { backgroundColor: '#ffd1d1' }),
     ...(variant === Variant.DYNAMIC && { backgroundColor: '#75ade4' }),
-    ...(filtered && { color: grey[600], filter: 'grayscale(1)' }),
+    ...(filtered && { color: theme.palette.text.disabled, backgroundColor: '#cccccc', filter: 'grayscale(1)' }),
 }));
 
 const Screen: React.FC<ScreenProps> = ({ title, fields, appVersions, variant, filtered }) => {

--- a/src/components/ScreensGrid.tsx
+++ b/src/components/ScreensGrid.tsx
@@ -1,0 +1,46 @@
+import { shallowEqual } from 'react-redux';
+import Alert from '@mui/material/Alert';
+import Grid from '@mui/material/Grid';
+import Skeleton from '@mui/material/Skeleton';
+
+import isEmpty from 'helpers/isEmpty';
+import { useAppSelector } from 'hooks/redux-hooks';
+import { ScreenType, selectScreensList, selectScreensLoadingStatus } from 'models/screens';
+
+import Screen, { Variant } from 'components/Screen';
+
+const variant = new Map<ScreenType, Variant>([
+    ['STATIC', Variant.STATIC],
+    ['DYNAMIC', Variant.DYNAMIC],
+]);
+
+const ScreensGrid: React.FC = () => {
+    const screensList = useAppSelector(selectScreensList, shallowEqual);
+    const isLoading = useAppSelector(selectScreensLoadingStatus);
+
+    if (isLoading) {
+        return <Skeleton component="div" variant="rounded" width={200} height={280} />;
+    }
+
+    if (isEmpty(screensList)) {
+        return <Alert severity="info">Нет ни одного экрана.</Alert>;
+    }
+
+    return (
+        <Grid container spacing={{ xs: 2, sm: 4 }} justifyContent={{ xs: 'center', sm: 'flex-start' }}>
+            {screensList.map(({ id, title, type, fields, appVersions, filtered }) => (
+                <Grid key={id} item xs="auto">
+                    <Screen
+                        title={title}
+                        fields={fields}
+                        appVersions={appVersions}
+                        variant={variant.get(type)}
+                        filtered={filtered}
+                    />
+                </Grid>
+            ))}
+        </Grid>
+    );
+};
+
+export default ScreensGrid;

--- a/src/layouts/LayerLayout.tsx
+++ b/src/layouts/LayerLayout.tsx
@@ -29,7 +29,7 @@ const drawerWidth = 290;
 const LayerLayout: React.FC<LayerLayoutProps> = ({ children, title, drawerOptions, loading }) => {
     const [open, setOpen] = useState(false);
     const theme = useTheme();
-    const isSmallWindow = useMediaQuery(theme.breakpoints.down('md'));
+    const isSmallWindow = useMediaQuery(theme.breakpoints.down('lg'));
 
     const handleDrawerToggle = useCallback(() => {
         setOpen(!open);

--- a/src/models/screens.ts
+++ b/src/models/screens.ts
@@ -171,7 +171,7 @@ const MOCK_SCREENS: ScreensList = [
     {
         id: 10,
         title: 'main_3_3',
-        type: 'DYNAMIC',
+        type: 'STATIC',
         filtered: true,
         fields: [
             { id: 1, title: 'Имя' },

--- a/src/models/screens.ts
+++ b/src/models/screens.ts
@@ -1,0 +1,250 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { ApiError, apiErrorHandler } from 'api';
+import { RootState } from 'store';
+
+export interface Field {
+    id: number;
+    title: string;
+}
+export type FieldsList = Field[];
+
+export interface Version {
+    id: number;
+    platform: string;
+    version?: string;
+}
+export type VersionsList = Version[];
+
+const SCREEN_TYPES = ['STATIC', 'DYNAMIC'] as const;
+export type ScreenType = (typeof SCREEN_TYPES)[number];
+export interface Screen {
+    id: number;
+    title: string;
+    type: ScreenType;
+    fields: FieldsList;
+    appVersions: VersionsList;
+    filtered?: boolean;
+}
+export type ScreensList = Screen[];
+
+// Удалить когда будет ручка
+const MOCK_SCREENS: ScreensList = [
+    {
+        id: 1,
+        title: 'main_1_45',
+        type: 'STATIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 2, title: 'Фамилия' },
+            { id: 3, title: 'Гражданство' },
+            { id: 4, title: 'Разрешение на работу' },
+        ],
+        appVersions: [
+            { id: 1, platform: 'iOS', version: '3.7+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 2,
+        title: 'experience_24',
+        type: 'DYNAMIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+        ],
+        appVersions: [
+            { id: 1, platform: 'iOS', version: '3.7+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 3,
+        title: 'main_1_46',
+        type: 'STATIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 2, title: 'Фамилия' },
+            { id: 3, title: 'Гражданство' },
+            { id: 6, title: 'Город' },
+        ],
+        appVersions: [
+            { id: 4, platform: 'iOS', version: '3.8+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 4,
+        title: 'main_3_3',
+        type: 'DYNAMIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 5,
+        title: 'main_3_3',
+        type: 'DYNAMIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 6,
+        title: 'main_3_3',
+        type: 'STATIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 7,
+        title: 'main_3_3',
+        type: 'STATIC',
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 8,
+        title: 'main_3_3',
+        type: 'DYNAMIC',
+        filtered: true,
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 9,
+        title: 'main_3_3',
+        type: 'DYNAMIC',
+        filtered: true,
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+    {
+        id: 10,
+        title: 'main_3_3',
+        type: 'DYNAMIC',
+        filtered: true,
+        fields: [
+            { id: 1, title: 'Имя' },
+            { id: 5, title: 'Опыт работы' },
+            { id: 7, title: 'Портфолио' },
+        ],
+        appVersions: [
+            { id: 5, platform: 'iOS', version: '3.9+' },
+            { id: 2, platform: 'Android', version: '1.4+' },
+            { id: 3, platform: 'Web' },
+        ],
+    },
+];
+
+const fetchScreens = createAsyncThunk<ScreensList, undefined, { rejectValue: ApiError }>(
+    'screens/fetchScreens',
+    async (_, thunkApi) => {
+        let response: ScreensList;
+        try {
+            response = await new Promise((resolve) => {
+                setTimeout(() => resolve(MOCK_SCREENS), 3000);
+            });
+        } catch (error) {
+            return thunkApi.rejectWithValue(apiErrorHandler(error));
+        }
+
+        return response;
+    }
+);
+
+interface ScreensState {
+    items: ScreensList;
+    isLoading: boolean;
+    error: ApiError | null;
+}
+
+const initialState: ScreensState = {
+    items: [],
+    isLoading: true,
+    error: null,
+};
+
+const screensSlice = createSlice({
+    name: 'screens',
+    initialState,
+    reducers: {
+        reset: (state) => {
+            state = initialState;
+            return state;
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchScreens.pending, (state) => {
+                state.isLoading = true;
+                state.error = null;
+            })
+            .addCase(fetchScreens.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.items = action.payload;
+            })
+            .addCase(fetchScreens.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload || { message: 'Произошла непредвиденная ошибка' };
+            });
+    },
+});
+
+const selectScreensList = (state: RootState): ScreensList => state.screens.items;
+const selectScreensError = (state: RootState): ApiError | null => state.screens.error;
+const selectScreensLoadingStatus = (state: RootState): boolean => state.screens.isLoading;
+
+const { reset } = screensSlice.actions;
+
+export default screensSlice.reducer;
+export { reset, fetchScreens, selectScreensList, selectScreensError, selectScreensLoadingStatus };

--- a/src/pages/CreateNewScreen.tsx
+++ b/src/pages/CreateNewScreen.tsx
@@ -1,0 +1,13 @@
+import SecondaryLayout from 'layouts/SecondaryLayout';
+
+import UnderConstructionPage from 'pages/UnderConstructionPage';
+
+const CreateNewScreen: React.FC = () => {
+    return (
+        <SecondaryLayout title="Новый экран" backHref="/screens">
+            <UnderConstructionPage pageName="Создание нового экрана" />
+        </SecondaryLayout>
+    );
+};
+
+export default CreateNewScreen;

--- a/src/pages/ScreensPage.tsx
+++ b/src/pages/ScreensPage.tsx
@@ -1,7 +1,76 @@
-import UnderConstructionPage from 'pages/UnderConstructionPage';
+import { useEffect } from 'react';
+import { shallowEqual } from 'react-redux';
+import FilterAltIcon from '@mui/icons-material/FilterAlt';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import InputAdornment from '@mui/material/InputAdornment';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+import AddButton from 'components/AddButton';
+import ScreensGrid from 'components/ScreensGrid';
+import { useAppDispatch, useAppSelector } from 'hooks/redux-hooks';
+import useErrorAlert from 'hooks/useErrorAlert';
+import { fetchScreens, reset, selectScreensError, selectScreensLoadingStatus } from 'models/screens';
 
 const ScreensPage: React.FC = () => {
-    return <UnderConstructionPage pageName="Экраны" />;
+    const dispatch = useAppDispatch();
+    const { setAlert } = useErrorAlert();
+    const isLoading = useAppSelector(selectScreensLoadingStatus);
+    const error = useAppSelector(selectScreensError, shallowEqual);
+
+    useEffect(() => {
+        void dispatch(fetchScreens());
+        return () => {
+            dispatch(reset());
+        };
+    }, [dispatch]);
+
+    useEffect(() => {
+        if (error !== null) {
+            setAlert(error.message);
+        }
+    }, [error, setAlert]);
+
+    return (
+        <>
+            <Stack direction="row" justifyContent="space-between" gap={2} sx={{ mt: 5, mb: 4 }}>
+                <Typography component="h2" variant="h5">
+                    Экраны
+                </Typography>
+                <Box sx={{ width: 'max-content' }}>
+                    <AddButton href="/new/screen" disabled={isLoading}>
+                        Новый экран
+                    </AddButton>
+                </Box>
+            </Stack>
+            <Box sx={{ maxWidth: 400, pb: 4 }}>
+                <Autocomplete
+                    options={['Все']}
+                    renderInput={(params) => (
+                        <TextField
+                            {...params}
+                            label="Версия приложения"
+                            InputProps={{
+                                ...params.InputProps,
+                                startAdornment: (
+                                    <>
+                                        <InputAdornment position="start">
+                                            <FilterAltIcon />
+                                        </InputAdornment>
+                                        {params.InputProps.startAdornment}
+                                    </>
+                                ),
+                            }}
+                        />
+                    )}
+                    disabled={isLoading}
+                />
+            </Box>
+            <ScreensGrid />
+        </>
+    );
 };
 
 export default ScreensPage;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import App from 'App';
 import CreateNewFieldPage from 'pages/CreateNewFieldPage';
 import CreateNewLayerPage from 'pages/CreateNewLayerPage';
+import CreateNewScreen from 'pages/CreateNewScreen';
 import EntryPointPage from 'pages/EntryPointPage';
 import EntryPointsPage from 'pages/EntryPointsPage';
 import FieldGroupsPage from 'pages/FieldGroupsPage';
@@ -53,6 +54,7 @@ const router = createBrowserRouter([
             { path: 'fields/:fieldId', element: <FieldPage /> },
             { path: 'new/layer', element: <CreateNewLayerPage /> },
             { path: 'new/field', element: <CreateNewFieldPage /> },
+            { path: 'new/screen', element: <CreateNewScreen /> },
         ],
     },
     { path: '/not-found', element: <NotFoundPage /> },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import currentLayerReducer from 'models/currentLayer';
 import fieldsReducer from 'models/fields';
 import layerChangesReducer from 'models/layerChanges';
 import layersListReducer from 'models/layersList';
+import screensReducer from 'models/screens';
 
 export const store = configureStore({
     reducer: {
@@ -13,6 +14,7 @@ export const store = configureStore({
         currentLayerChanges: layerChangesReducer,
         fields: fieldsReducer,
         currentField: currentFieldReducer,
+        screens: screensReducer,
     },
 });
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -4,15 +4,6 @@ import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 import LinkBehavior from 'components/LinkBehavior';
 
 const theme = createTheme({
-    breakpoints: {
-        values: {
-            xs: 0,
-            sm: 600,
-            md: 961,
-            lg: 1200,
-            xl: 1536,
-        },
-    },
     // https://mui.com/material-ui/guides/routing/#global-theme-link
     components: {
         MuiLink: {


### PR DESCRIPTION
- убрал кастомный брейкпойнт, так как в нем нет смысла, того же эффекта можно добиться со стандартными брейкпойнтами;
- добавил заготовку модели для экранов с моковыми данными;
- добавил компонент Screen и ScreensGrid для отображения экранов;
- добавил заготовку для страницы создания экрана;
- сверстал страницу ScreensPage;

![Снимок экрана от 2023-05-17 12-09-47](https://github.com/hhru-school/segment-admin-panel-front/assets/84242545/69fe01a5-5121-4fae-bf56-aec0d3196f20)
![Снимок экрана от 2023-05-17 12-10-13](https://github.com/hhru-school/segment-admin-panel-front/assets/84242545/5964aca5-9967-43ff-8b89-c1b69b7bf55c)

**загрузка**
![Снимок экрана от 2023-05-17 12-09-55](https://github.com/hhru-school/segment-admin-panel-front/assets/84242545/b5806bdb-6755-4168-8d5f-0fac12d7b04e)

**нет данных**
![Снимок экрана от 2023-05-17 12-10-53](https://github.com/hhru-school/segment-admin-panel-front/assets/84242545/788d8057-ed0b-4e6e-a57a-7bf81cc9a88f)
